### PR TITLE
Fix offset issues

### DIFF
--- a/Sources/Views/HStackSnapCore.swift
+++ b/Sources/Views/HStackSnapCore.swift
@@ -90,6 +90,7 @@ public struct HStackSnapCore<Content: View>: View {
                     eventHandler?(.didLayout(layoutInfo: itemScrollPositions))
                 }
             })
+            .contentShape(Rectangle())
             .gesture(snapDrag)
         }
         .coordinateSpace(name: coordinateSpace)

--- a/Sources/Views/HStackSnapCore.swift
+++ b/Sources/Views/HStackSnapCore.swift
@@ -21,6 +21,7 @@ public struct HStackSnapCore<Content: View>: View {
         self.scrollOffset = leadingOffset
         self.coordinateSpace = coordinateSpace
         self.eventHandler = eventHandler
+        self._prevScrollOffset = State(initialValue: leadingOffset)
     }
 
     // MARK: Public
@@ -153,7 +154,7 @@ public struct HStackSnapCore<Content: View>: View {
     @State private var scrollOffset: CGFloat
 
     /// Stored offset of previous scroll, so scroll state is resumed between drags.
-    @State private var prevScrollOffset: CGFloat = 0
+    @State private var prevScrollOffset: CGFloat
 
     /// Calculated offset based on `SnapLocation`
     @State private var targetOffset: CGFloat


### PR DESCRIPTION
## Jump on first drag
If there is an offset in the `SnapAlignment`, the first drag will cause a jump as large as the `leadingOffset` because the `prevScrollOffset` is set 0. To avoid this jump I set the `prevScrollOffset` to the `leadingOffset` to compensate.

## Drag on container
Isn't possible to drag on the container, only on the children inside the container, so I added the `.contentShape` modifier to allow dragging on empty areas before and after the items.