### PR TITLE
Replace Example2ContentView with Example1ContentView

### DIFF
--- a/SnapToScrollDemo/Sources/Example1/Example1ContentView.swift
+++ b/SnapToScrollDemo/Sources/Example1/Example1ContentView.swift
@@ -30,6 +30,6 @@ struct Example1ContentView: View {
 
 struct Example1ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        Example2ContentView()
+        Example1ContentView()
     }
 }


### PR DESCRIPTION
### Title
- Replace Example2ContentView with Example1ContentView

### Description
- This change updates the view reference in the source from Example2ContentView() to Example1ContentView(). It ensures that the correct example is used in both code and previews:

#### Before

```swift
Example2ContentView()
```

#### After

```swift
Example1ContentView()
```

